### PR TITLE
moduleclass_sfx throws PHP-Notice in default.php

### DIFF
--- a/mod_ccctwoclick/mod_ccctwoclick.php
+++ b/mod_ccctwoclick/mod_ccctwoclick.php
@@ -26,5 +26,6 @@ $disabledimage = $params->get('disabledimage', '');
 $backgroundsize = $params->get('backgroundsize', 'contain');
 $stylesheet = $params->get('stylesheet', "yes");
 $moduleId = $module->id;
+$moduleclass_sfx = $params->get('moduleclass_sfx', '');
 
 require JModuleHelper::getLayoutPath('mod_ccctwoclick', $params->get('layout', 'default'));


### PR DESCRIPTION
### Testing
- Activate Error Reporting in Joomla configuration ("Maximum").
- Create a mod_ccctwoclick module.
- See Notice in HTML source code (frontend)
```
<div class="ccctwoclickcontainer-109 
Notice: Undefined variable: moduleclass_sfx in /modules/mod_ccctwoclick/tmpl/default.php on line 65
" style="width:100%; margin:0pt auto;">
```
- Apply patch.
- Try again.