### PR TITLE
Add field for alternative layout (template override)

### DIFF
--- a/mod_ccctwoclick/mod_ccctwoclick.xml
+++ b/mod_ccctwoclick/mod_ccctwoclick.xml
@@ -294,6 +294,13 @@
 				</field>
 
 				<field
+						name="layout"
+						label="JFIELD_ALT_LAYOUT_LABEL"
+						type="modulelayout"
+						description="JFIELD_ALT_MODULE_LAYOUT_DESC"
+				/>
+
+				<field
 						name="moduleclass_sfx"
 						label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 						type="textarea"


### PR DESCRIPTION
### Testing
- Create a custom/alternative module layout (template override), e.g. `templates/YOURTEMPLATENAME/html/mod_ccctwoclick/youtube.php`
- Go into module settings. There is no select box named "Layout" to select it.
- Apply patch.
- Now you'll find it in `Advanced` tabulator and can select your custom/advanced layout `youtube.php` there
- Add some specific code into this file to check that it is used now in frontend instead of `default.php`.
